### PR TITLE
ci(dependabot): exclude GH workflows from pip checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     schedule:
       interval: weekly
   - package-ecosystem: pip
-    directory: "/.github/workflows"
-    schedule:
-      interval: weekly
-  - package-ecosystem: pip
     directory: "/docs"
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

Remove non-relevant dependabot check of PIP dependencies in .github dir

## Related Issue

N/A

## Changes Made

<!-- List the changes that were made in this PR. -->

- [x] Remove non-relevant dependabot check of PIP dependencies in .github dir

## Checklist

- [x] ~Tests added or updated~
- [x] ~Documentation updated (if necessary)~
- [x] All tests pass
- [x] Code is well-documented

## Screenshots or Additional Context (if applicable)

N/A

## Notes for Reviewer

N/A
